### PR TITLE
Update concerto_content_scheduling.gemspec

### DIFF
--- a/concerto_content_scheduling.gemspec
+++ b/concerto_content_scheduling.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 3.2.9"
+  s.add_dependency "rails", "~> 4.1.6"
   s.add_dependency "jquery-timepicker-rails"
   s.add_dependency "ice_cube"
   s.add_dependency "recurring_select", '~> 1.2.1rc3'


### PR DESCRIPTION
A user emailed in mentioning the Rails version needed to be updated in the gemspec for this plugin to work, otherwise passenger cannot start Concerto.

I can't change this myself since I'm not a project collaborator for this repository. 
